### PR TITLE
MANTA-5189 update cueball to use artedi 2.x

### DIFF
--- a/CHANGES.adoc
+++ b/CHANGES.adoc
@@ -6,6 +6,14 @@ toc::[]
 
 ## v2.x
 
+### v2.10.1
+
+Maintenance release.
+
+Bugs fixed:
+
+ - MANTA-5189 Bump artedi dep from 1.x to 2.x.
+
 ### v2.10.0
 
 New minor release, due to addition of new API.

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "cueball",
-  "version": "2.10.0",
+  "version": "2.10.1",
   "description": "manage a pool of connections to a multi-node service where nodes are listed in DNS",
   "main": "lib/index.js",
   "dependencies": {
-    "artedi": "1.3.0",
+    "artedi": "~2.0.2",
     "assert-plus": ">=1.0.0 <2.0.0",
     "bunyan": ">=1.5.1 <2.0.0",
     "cmdutil": ">=1.0.0 <2.0.0",


### PR DESCRIPTION
`make check` passes.

`make test` I'm still running.